### PR TITLE
output_as_stream to optional from runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,4 +335,4 @@ ASALocalRun/
 .pnpm*
 .vscode/
 *.sqlite3*
-
+*.dylib

--- a/app/src/app/runner.rs
+++ b/app/src/app/runner.rs
@@ -306,7 +306,7 @@ pub mod test {
             job_args_proto: include_str!("../../../proto/protobuf/test_args.proto").to_string(),
             runner_type: RunnerType::Plugin as i32,
             result_output_proto: None,
-            output_as_stream: false,
+            output_as_stream: Some(false),
         }
     }
 

--- a/app/src/app/worker/hybrid.rs
+++ b/app/src/app/worker/hybrid.rs
@@ -85,7 +85,10 @@ impl WorkerApp for HybridWorkerAppImpl {
                 JobWorkerError::InvalidParameter("runner settings not provided".to_string())
             })?;
         let mut wdata = worker.clone();
-        wdata.output_as_stream = runner_data.output_as_stream;
+        // overwrite output_as_stream only if data is provided from runner
+        if let Some(output_as_stream) = runner_data.output_as_stream {
+            wdata.output_as_stream = output_as_stream;
+        }
         let wid = {
             let db = self.rdb_worker_repository().db_pool();
             let mut tx = db.begin().await.map_err(JobWorkerError::DBError)?;
@@ -129,7 +132,10 @@ impl WorkerApp for HybridWorkerAppImpl {
                         JobWorkerError::InvalidParameter("runner settings not provided".to_string())
                     })?;
                 let mut wdata = w.clone();
-                wdata.output_as_stream = runner_data.output_as_stream;
+                // overwrite output_as_stream only if data is provided from runner
+                if let Some(output_as_stream) = runner_data.output_as_stream {
+                    wdata.output_as_stream = output_as_stream;
+                }
 
                 // use rdb
                 let pool = self.rdb_worker_repository().db_pool();

--- a/infra/src/infra/runner.rs
+++ b/infra/src/infra/runner.rs
@@ -28,5 +28,5 @@ pub trait RunnerTrait: Send + Sync {
     fn job_args_proto(&self) -> String;
     fn result_output_proto(&self) -> Option<String>;
     // run with run_stream() if true
-    fn output_as_stream(&self) -> bool;
+    fn output_as_stream(&self) -> Option<bool>;
 }

--- a/infra/src/infra/runner/command.rs
+++ b/infra/src/infra/runner/command.rs
@@ -157,8 +157,8 @@ impl RunnerTrait for CommandRunnerImpl {
     fn result_output_proto(&self) -> Option<String> {
         Some("".to_string())
     }
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }
 

--- a/infra/src/infra/runner/docker.rs
+++ b/infra/src/infra/runner/docker.rs
@@ -307,8 +307,8 @@ impl RunnerTrait for DockerExecRunner {
     fn result_output_proto(&self) -> Option<String> {
         None
     }
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }
 
@@ -526,8 +526,8 @@ impl RunnerTrait for DockerRunner {
     fn result_output_proto(&self) -> Option<String> {
         Some("".to_string())
     }
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }
 

--- a/infra/src/infra/runner/grpc_unary.rs
+++ b/infra/src/infra/runner/grpc_unary.rs
@@ -100,8 +100,8 @@ impl RunnerTrait for GrpcUnaryRunner {
     fn result_output_proto(&self) -> Option<String> {
         None
     }
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }
 

--- a/infra/src/infra/runner/plugins.rs
+++ b/infra/src/infra/runner/plugins.rs
@@ -24,7 +24,7 @@ trait PluginRunner: Send + Sync {
     fn runner_settings_proto(&self) -> String;
     fn job_args_proto(&self) -> String;
     fn result_output_proto(&self) -> Option<String>;
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }

--- a/infra/src/infra/runner/plugins/impls.rs
+++ b/infra/src/infra/runner/plugins/impls.rs
@@ -137,7 +137,7 @@ impl RunnerTrait for PluginRunnerWrapperImpl {
     fn result_output_proto(&self) -> Option<String> {
         block_on(self.plugin_runner.read()).result_output_proto()
     }
-    fn output_as_stream(&self) -> bool {
+    fn output_as_stream(&self) -> Option<bool> {
         block_on(self.plugin_runner.read()).output_as_stream()
     }
 }

--- a/infra/src/infra/runner/rdb.rs
+++ b/infra/src/infra/runner/rdb.rs
@@ -265,7 +265,7 @@ mod test {
                     .to_string(),
             ),
             runner_type: 0,
-            output_as_stream: true, // hello
+            output_as_stream: Some(true), // hello
         });
 
         let org_count = repository.count_list_tx(repository.db_pool()).await?;

--- a/infra/src/infra/runner/redis.rs
+++ b/infra/src/infra/runner/redis.rs
@@ -250,7 +250,7 @@ async fn redis_test() -> Result<()> {
         runner_settings_proto: "hoge3".to_string(),
         job_args_proto: "hoge5".to_string(),
         result_output_proto: Some("hoge7".to_string()),
-        output_as_stream: false,
+        output_as_stream: Some(false),
     };
     // clear first
     repo.delete(&id).await?;

--- a/infra/src/infra/runner/request.rs
+++ b/infra/src/infra/runner/request.rs
@@ -150,8 +150,8 @@ impl RunnerTrait for RequestRunner {
                 .to_string(),
         )
     }
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }
 

--- a/infra/src/infra/runner/slack.rs
+++ b/infra/src/infra/runner/slack.rs
@@ -99,7 +99,7 @@ impl RunnerTrait for SlackPostMessageRunner {
     fn result_output_proto(&self) -> Option<String> {
         Some(include_str!("../../../protobuf/jobworkerp/runner/slack_result.proto").to_string())
     }
-    fn output_as_stream(&self) -> bool {
-        false
+    fn output_as_stream(&self) -> Option<bool> {
+        Some(false)
     }
 }

--- a/proto/protobuf/jobworkerp/data/runner.proto
+++ b/proto/protobuf/jobworkerp/data/runner.proto
@@ -20,7 +20,9 @@ message RunnerData {
   // message type prefix (e.g. "message CommandResult{ string result = 1; }") if
   // empty, use utf8 string as bytes array for result output(or not resolved)
   optional string result_output_proto = 5;
-  bool output_as_stream = 6; // if true, output as stream (defined by runner impl)
+  // if true, output as stream
+  // (defined by runner impl. none: implement both stream and non-stream. can specify in worker)
+  optional bool output_as_stream = 6;
 }
 
 message RunnerId { int64 value = 1; }

--- a/worker-app/src/worker/runner.rs
+++ b/worker-app/src/worker/runner.rs
@@ -122,7 +122,7 @@ pub trait JobRunner:
         let start = datetime::now_millis();
 
         let name = runner_impl.name();
-        if runner_impl.output_as_stream() {
+        if worker_data.output_as_stream {
             tracing::debug!("start runner(stream): {}", &name);
             let res = self
                 .run_and_stream(&job, runner_impl)


### PR DESCRIPTION
if implement both run() and run_stream() in runner, can select output as streaming or not by worker data.